### PR TITLE
Use tls1.2 for powershell web requests

### DIFF
--- a/lib/vmtools_win/vmtools_win_online_file.ps1
+++ b/lib/vmtools_win/vmtools_win_online_file.ps1
@@ -1,3 +1,4 @@
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $packagestore = "http://packages.vmware.com/tools/releases/latest/windows/x64"
 $success = $false
 

--- a/lib/vmtools_win/vmtools_win_online_version.ps1
+++ b/lib/vmtools_win/vmtools_win_online_version.ps1
@@ -1,3 +1,4 @@
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $packagestore = "http://packages.vmware.com/tools/releases/latest/windows/x64"
 $success = $false
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class vmtools_win (
       #Sanity checks before continuing
       if $download_from_vmware {
         unless ($facts['vmtools_win_online_version']) and ($facts['vmtools_win_online_file']) {
-          fail ('download_from_vmware was set to true but this host is not able to access http://packages.vmware.com!')
+          fail ('download_from_vmware was set to true but this host is not able to access https://packages.vmware.com!')
         }
       }
       else {
@@ -32,7 +32,7 @@ class vmtools_win (
 
       #Build values for installation or cleanup
       if $download_from_vmware {
-        $file_source = 'http://packages.vmware.com/tools/releases/latest/windows/x64'
+        $file_source = 'https://packages.vmware.com/tools/releases/latest/windows/x64'
         $file_name   = $facts['vmtools_win_online_file']
       }
       else {


### PR DESCRIPTION
Powershell script srefuse to connect to packages.vmware.com resulting in empty version information.

This forces tls1.2 and then downloads the package via https